### PR TITLE
Setup MonoGame base with isometric camera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+bin/
+obj/
+*.user
+*.suo
+*.vs/
+**/Content/bin/
+**/Content/obj/
+
+# Generated textures
+TheatreGame/Content/*.png

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # le_roi_en_jaune
-Jeu 3D isométrique
+
+Prototype de jeu 3D isométrique utilisant MonoGame.
+
+## Installation
+
+1. Installer le SDK .NET 6.0.
+2. Restaurer les dépendances du projet :
+   ```bash
+   dotnet restore
+   ```
+3. Installer la dépendance Python Pillow :
+   ```bash
+   pip install --user pillow
+   ```
+4. Générer les textures nécessaires :
+   ```bash
+   python3 generate_textures.py
+   ```
+5. Lancer le jeu :
+   ```bash
+   dotnet run --project TheatreGame
+   ```
+
+## Détails
+
+- Fenêtre : 1280x720
+- Caméra : perspective isométrique simple
+- Les textures de la scène sont générées avec `generate_textures.py`.

--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -1,0 +1,108 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+
+namespace TheatreGame
+{
+    public class Game1 : Game
+    {
+        private GraphicsDeviceManager _graphics;
+        private SpriteBatch _spriteBatch;
+
+        private Matrix _viewMatrix;
+        private Matrix _projectionMatrix;
+
+        private VertexPositionTexture[] _floorVertices;
+        private VertexPositionTexture[] _curtainVertices;
+        private BasicEffect _effect;
+        private Texture2D _floorTexture;
+        private Texture2D _curtainTexture;
+
+        public Game1()
+        {
+            _graphics = new GraphicsDeviceManager(this);
+            Content.RootDirectory = "Content";
+            IsMouseVisible = true;
+            _graphics.PreferredBackBufferWidth = 1280;
+            _graphics.PreferredBackBufferHeight = 720;
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+
+            // Set up isometric camera
+            var cameraPosition = new Vector3(20, 20, 20);
+            var target = Vector3.Zero;
+            var up = Vector3.Up;
+            _viewMatrix = Matrix.CreateLookAt(cameraPosition, target, up);
+            _projectionMatrix = Matrix.CreatePerspectiveFieldOfView(MathHelper.ToRadians(45f),
+                GraphicsDevice.Viewport.AspectRatio, 0.1f, 100f);
+
+            // Create floor quad
+            _floorVertices = new VertexPositionTexture[6];
+            _floorVertices[0] = new VertexPositionTexture(new Vector3(-10, 0, -10), new Vector2(0, 0));
+            _floorVertices[1] = new VertexPositionTexture(new Vector3(-10, 0, 10), new Vector2(0, 1));
+            _floorVertices[2] = new VertexPositionTexture(new Vector3(10, 0, -10), new Vector2(1, 0));
+            _floorVertices[3] = new VertexPositionTexture(new Vector3(10, 0, -10), new Vector2(1, 0));
+            _floorVertices[4] = new VertexPositionTexture(new Vector3(-10, 0, 10), new Vector2(0, 1));
+            _floorVertices[5] = new VertexPositionTexture(new Vector3(10, 0, 10), new Vector2(1, 1));
+
+            // Create curtain quad behind the stage
+            _curtainVertices = new VertexPositionTexture[6];
+            _curtainVertices[0] = new VertexPositionTexture(new Vector3(-10, 0, -10), new Vector2(0, 1));
+            _curtainVertices[1] = new VertexPositionTexture(new Vector3(10, 0, -10), new Vector2(1, 1));
+            _curtainVertices[2] = new VertexPositionTexture(new Vector3(-10, 10, -10), new Vector2(0, 0));
+            _curtainVertices[3] = new VertexPositionTexture(new Vector3(-10, 10, -10), new Vector2(0, 0));
+            _curtainVertices[4] = new VertexPositionTexture(new Vector3(10, 0, -10), new Vector2(1, 1));
+            _curtainVertices[5] = new VertexPositionTexture(new Vector3(10, 10, -10), new Vector2(1, 0));
+        }
+
+        protected override void LoadContent()
+        {
+            _spriteBatch = new SpriteBatch(GraphicsDevice);
+
+            _effect = new BasicEffect(GraphicsDevice)
+            {
+                TextureEnabled = true,
+                VertexColorEnabled = false
+            };
+
+            _floorTexture = Content.Load<Texture2D>("stage_floor");
+            _curtainTexture = Content.Load<Texture2D>("curtain");
+        }
+
+        protected override void Update(GameTime gameTime)
+        {
+            if (Keyboard.GetState().IsKeyDown(Keys.Escape))
+                Exit();
+
+            base.Update(gameTime);
+        }
+
+        protected override void Draw(GameTime gameTime)
+        {
+            GraphicsDevice.Clear(Color.CornflowerBlue);
+
+            _effect.View = _viewMatrix;
+            _effect.Projection = _projectionMatrix;
+            _effect.World = Matrix.Identity;
+            _effect.Texture = _floorTexture;
+
+            foreach (var pass in _effect.CurrentTechnique.Passes)
+            {
+                pass.Apply();
+                GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, _floorVertices, 0, 2);
+            }
+
+            _effect.Texture = _curtainTexture;
+            foreach (var pass in _effect.CurrentTechnique.Passes)
+            {
+                pass.Apply();
+                GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, _curtainVertices, 0, 2);
+            }
+
+            base.Draw(gameTime);
+        }
+    }
+}

--- a/TheatreGame/Program.cs
+++ b/TheatreGame/Program.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace TheatreGame
+{
+    public static class Program
+    {
+        [STAThread]
+        static void Main()
+        {
+            using var game = new Game1();
+            game.Run();
+        }
+    }
+}

--- a/TheatreGame/TheatreGame.csproj
+++ b/TheatreGame/TheatreGame.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>TheatreGame</RootNamespace>
+    <UseMonoGame>true</UseMonoGame>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+  </ItemGroup>
+</Project>

--- a/generate_textures.py
+++ b/generate_textures.py
@@ -1,0 +1,19 @@
+from PIL import Image, ImageDraw
+import os
+
+os.makedirs('TheatreGame/Content', exist_ok=True)
+
+# Stage floor: wooden planks
+width, height = 256, 256
+floor = Image.new('RGB', (width, height), (150, 100, 50))
+draw = ImageDraw.Draw(floor)
+for y in range(0, height, 32):
+    draw.rectangle([0, y, width, y+2], fill=(130, 80, 40))
+floor.save('TheatreGame/Content/stage_floor.png')
+
+# Simple red curtain texture
+curtain = Image.new('RGB', (width, height), (160, 20, 40))
+curtain_draw = ImageDraw.Draw(curtain)
+for x in range(0, width, 16):
+    curtain_draw.rectangle([x, 0, x+8, height], fill=(140, 10, 30))
+curtain.save('TheatreGame/Content/curtain.png')


### PR DESCRIPTION
## Summary
- add initial MonoGame project skeleton
- implement simple isometric camera and stage draw
- generate basic stage textures via `generate_textures.py`
- add README instructions and .gitignore
- remove binary textures and document generation

## Testing
- `python3 generate_textures.py`


------
https://chatgpt.com/codex/tasks/task_e_6844aa24dbc48326b0b34eeb9e559273