### PR TITLE
Fix missing textures at runtime

### DIFF
--- a/TheatreGame/TheatreGame.csproj
+++ b/TheatreGame/TheatreGame.csproj
@@ -8,4 +8,9 @@
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Content/**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- copy theatre textures to the build output so the game can load them

## Testing
- `python -m py_compile generate_textures.py`

------
https://chatgpt.com/codex/tasks/task_e_6844afa200a0832699fa1bd7a88ccc4c