### PR TITLE
Fix blank screen due to culling

### DIFF
--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -92,6 +92,12 @@ namespace TheatreGame
         {
             GraphicsDevice.Clear(Color.CornflowerBlue);
 
+            // The quads are defined with a counter-clockwise winding order.
+            // MonoGame culls counter-clockwise primitives by default, which
+            // resulted in nothing being rendered and the screen staying blue.
+            // Switch to culling clockwise faces so our geometry becomes visible.
+            GraphicsDevice.RasterizerState = RasterizerState.CullClockwise;
+
             _effect.View = _viewMatrix;
             _effect.Projection = _projectionMatrix;
             _effect.World = Matrix.Identity;


### PR DESCRIPTION
## Summary
- switch rasterizer to cull clockwise so the stage quads are visible

## Testing
- `python3 generate_textures.py`
- `python -m py_compile generate_textures.py`
- *(dotnet unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6844b0f04bf483269dada8c291cb3d96