### PR TITLE
Add gray checkerboard overlay

### DIFF
--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -19,6 +19,7 @@ namespace TheatreGame
         private BasicEffect _effect;
         private Texture2D _floorTexture;
         private Texture2D _curtainTexture;
+        private Texture2D _gridTexture;
 
         private Texture2D _particleTexture;
         private List<Particle> _lightParticles;
@@ -102,6 +103,9 @@ namespace TheatreGame
             _curtainTexture = Texture2D.FromStream(
                 GraphicsDevice,
                 TitleContainer.OpenStream("Content/curtain.png"));
+            _gridTexture = Texture2D.FromStream(
+                GraphicsDevice,
+                TitleContainer.OpenStream("Content/grid_overlay.png"));
 
             _particleTexture = new Texture2D(GraphicsDevice, 1, 1);
             _particleTexture.SetData(new[] { Color.White });
@@ -139,6 +143,16 @@ namespace TheatreGame
                 pass.Apply();
                 GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, _floorVertices, 0, 2);
             }
+
+            // Draw semi-transparent grid overlay on top of the floor
+            GraphicsDevice.BlendState = BlendState.AlphaBlend;
+            _effect.Texture = _gridTexture;
+            foreach (var pass in _effect.CurrentTechnique.Passes)
+            {
+                pass.Apply();
+                GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, _floorVertices, 0, 2);
+            }
+            GraphicsDevice.BlendState = BlendState.Opaque;
 
             _effect.Texture = _curtainTexture;
             foreach (var pass in _effect.CurrentTechnique.Passes)

--- a/generate_textures.py
+++ b/generate_textures.py
@@ -17,3 +17,16 @@ curtain_draw = ImageDraw.Draw(curtain)
 for x in range(0, width, 16):
     curtain_draw.rectangle([x, 0, x+8, height], fill=(140, 10, 30))
 curtain.save('TheatreGame/Content/curtain.png')
+
+# Transparent checkerboard overlay to delimit the board
+grid = Image.new('RGBA', (width, height), (0, 0, 0, 0))
+grid_draw = ImageDraw.Draw(grid)
+square = 32
+for y in range(0, height, square):
+    for x in range(0, width, square):
+        if ((x // square) + (y // square)) % 2 == 0:
+            color = (200, 200, 200, 80)
+        else:
+            color = (120, 120, 120, 80)
+        grid_draw.rectangle([x, y, x + square, y + square], fill=color)
+grid.save('TheatreGame/Content/grid_overlay.png')


### PR DESCRIPTION
## Summary
- generate a transparent checkerboard texture with Python
- load and render the board overlay in the MonoGame project

## Testing
- `pip install --user pillow`
- `python3 generate_textures.py`
- `dotnet build TheatreGame/TheatreGame.csproj -v:m` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b49b51088326aa5b1413457c7ab8