### PR TITLE
Ajout d'un feu de camp animé

### DIFF
--- a/generate_textures.py
+++ b/generate_textures.py
@@ -25,8 +25,29 @@ square = 32
 for y in range(0, height, square):
     for x in range(0, width, square):
         if ((x // square) + (y // square)) % 2 == 0:
-            color = (200, 200, 200, 80)
+            color = (200, 200, 200, 40)
         else:
-            color = (120, 120, 120, 80)
+            color = (120, 120, 120, 40)
         grid_draw.rectangle([x, y, x + square, y + square], fill=color)
 grid.save('TheatreGame/Content/grid_overlay.png')
+
+# Very simple campfire sprite
+fire = Image.new('RGBA', (64, 64), (0, 0, 0, 0))
+fire_draw = ImageDraw.Draw(fire)
+# logs
+fire_draw.rectangle([22, 44, 42, 50], fill=(110, 60, 30))
+fire_draw.rectangle([26, 50, 38, 54], fill=(110, 60, 30))
+# flames
+fire_draw.polygon([(32, 20), (20, 44), (44, 44)], fill=(255, 160, 0))
+fire_draw.polygon([(32, 28), (26, 44), (38, 44)], fill=(255, 220, 0))
+fire.save('TheatreGame/Content/campfire.png')
+
+# Radial light gradient used for the flickering light
+gradient = Image.new('RGBA', (64, 64), (0, 0, 0, 0))
+grad_draw = ImageDraw.Draw(gradient)
+center = (32, 32)
+for r in range(32, 0, -1):
+    alpha = int(255 * (r / 32))
+    grad_draw.ellipse([center[0]-r, center[1]-r, center[0]+r, center[1]+r],
+                     fill=(255, 200, 50, alpha))
+gradient.save('TheatreGame/Content/light_gradient.png')


### PR DESCRIPTION
## Summary
- génère de nouveaux sprites (feu de camp et halo lumineux) et rend le damier plus translucide
- ajoute les textures au jeu
- anime un feu central avec particules de flamme et de fumée
- applique un halo de lumière vacillant autour du feu

## Testing
- `python3 generate_textures.py`
- `dotnet build TheatreGame/TheatreGame.csproj -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844b637cd148326843832cb76aab486