### PR TITLE
Amélioration du feu de camp et génération de textures

### DIFF
--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -22,8 +22,10 @@ namespace TheatreGame
         private Texture2D _gridTexture;
 
         private Texture2D _campfireTexture;
+        private Texture2D _lightGradientTexture;
 
         private Texture2D _particleTexture;
+        private BasicEffect _colorEffect;
         private List<Particle> _lightParticles;
         private List<Particle> _dustParticles;
         private List<Particle> _fireParticles;
@@ -127,6 +129,16 @@ namespace TheatreGame
                 GraphicsDevice,
                 TitleContainer.OpenStream("Content/campfire.png"));
 
+            _lightGradientTexture = Texture2D.FromStream(
+                GraphicsDevice,
+                TitleContainer.OpenStream("Content/light_gradient.png"));
+
+            _colorEffect = new BasicEffect(GraphicsDevice)
+            {
+                TextureEnabled = false,
+                VertexColorEnabled = true
+            };
+
             _particleTexture = new Texture2D(GraphicsDevice, 1, 1);
             _particleTexture.SetData(new[] { Color.White });
         }
@@ -183,6 +195,7 @@ namespace TheatreGame
                 GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, _curtainVertices, 0, 2);
             }
 
+            DrawTileLights();
             DrawCampfire();
             DrawParticles();
 
@@ -277,11 +290,50 @@ namespace TheatreGame
         {
             float flicker = 0.8f + (float)_random.NextDouble() * 0.2f;
             _spriteBatch.Begin(blendState: BlendState.AlphaBlend);
-            _spriteBatch.Draw(_campfireTexture, _campfireScreenPos - new Vector2(32, 48),
+            _spriteBatch.Draw(_campfireTexture, _campfireScreenPos - new Vector2(32, 64),
                 null, Color.White, 0f, Vector2.Zero, 0.5f, SpriteEffects.None, 0f);
             _spriteBatch.Draw(_lightGradientTexture, _campfireScreenPos - new Vector2(128, 128),
                 null, Color.White * flicker, 0f, Vector2.Zero, 2f, SpriteEffects.None, 0f);
             _spriteBatch.End();
+        }
+
+        private void DrawTileLights()
+        {
+            const int range = 3;
+            const float tileSize = 20f / 8f; // board is 8x8 tiles on a 20x20 plane
+
+            _colorEffect.View = _viewMatrix;
+            _colorEffect.Projection = _projectionMatrix;
+            _colorEffect.World = Matrix.Identity;
+
+            GraphicsDevice.BlendState = BlendState.Additive;
+            for (int x = -range; x <= range - 1; x++)
+            {
+                for (int z = -range; z <= range - 1; z++)
+                {
+                    DrawTileQuad(x * tileSize, z * tileSize, tileSize,
+                        new Color(255, 240, 150, 100));
+                }
+            }
+            GraphicsDevice.BlendState = BlendState.Opaque;
+        }
+
+        private void DrawTileQuad(float startX, float startZ, float size, Color color)
+        {
+            VertexPositionColor[] verts = new VertexPositionColor[6];
+            float y = 0.01f; // slightly above floor to avoid z-fighting
+            verts[0] = new VertexPositionColor(new Vector3(startX, y, startZ), color);
+            verts[1] = new VertexPositionColor(new Vector3(startX + size, y, startZ), color);
+            verts[2] = new VertexPositionColor(new Vector3(startX + size, y, startZ + size), color);
+            verts[3] = new VertexPositionColor(new Vector3(startX + size, y, startZ + size), color);
+            verts[4] = new VertexPositionColor(new Vector3(startX, y, startZ + size), color);
+            verts[5] = new VertexPositionColor(new Vector3(startX, y, startZ), color);
+
+            foreach (var pass in _colorEffect.CurrentTechnique.Passes)
+            {
+                pass.Apply();
+                GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, verts, 0, 2);
+            }
         }
 
         private void SpawnParticlesAt(List<Particle> list, int count, Color color,

--- a/generate_textures.py
+++ b/generate_textures.py
@@ -3,20 +3,27 @@ import os
 
 os.makedirs('TheatreGame/Content', exist_ok=True)
 
+
+def save_if_missing(img: Image.Image, path: str):
+    """Save ``img`` to ``path`` only if the file does not already exist."""
+    if not os.path.exists(path):
+        img.save(path)
+
+
 # Stage floor: wooden planks
 width, height = 128, 128
 floor = Image.new('RGB', (width, height), (150, 100, 50))
 draw = ImageDraw.Draw(floor)
 for y in range(0, height, 16):
     draw.rectangle([0, y, width, y+1], fill=(130, 80, 40))
-floor.save('TheatreGame/Content/stage_floor.png')
+save_if_missing(floor, 'TheatreGame/Content/stage_floor.png')
 
 # Simple red curtain texture
 curtain = Image.new('RGB', (width, height), (160, 20, 40))
 curtain_draw = ImageDraw.Draw(curtain)
 for x in range(0, width, 8):
     curtain_draw.rectangle([x, 0, x+4, height], fill=(140, 10, 30))
-curtain.save('TheatreGame/Content/curtain.png')
+save_if_missing(curtain, 'TheatreGame/Content/curtain.png')
 
 # Transparent checkerboard overlay to delimit the board
 grid = Image.new('RGBA', (width, height), (0, 0, 0, 0))
@@ -29,7 +36,7 @@ for y in range(0, height, square):
         else:
             color = (120, 120, 120, 40)
         grid_draw.rectangle([x, y, x + square, y + square], fill=color)
-grid.save('TheatreGame/Content/grid_overlay.png')
+save_if_missing(grid, 'TheatreGame/Content/grid_overlay.png')
 
 
 # Very simple campfire sprite
@@ -41,7 +48,7 @@ fire_draw.rectangle([52, 100, 76, 108], fill=(110, 60, 30))
 # flames
 fire_draw.polygon([(64, 40), (40, 88), (88, 88)], fill=(255, 160, 0))
 fire_draw.polygon([(64, 56), (52, 88), (76, 88)], fill=(255, 220, 0))
-fire.save('TheatreGame/Content/campfire.png')
+save_if_missing(fire, 'TheatreGame/Content/campfire.png')
 
 # Radial light gradient used for the flickering light
 gradient = Image.new('RGBA', (128, 128), (0, 0, 0, 0))
@@ -51,4 +58,4 @@ for r in range(64, 0, -1):
     alpha = int(255 * (r / 64))
     grad_draw.ellipse([center[0]-r, center[1]-r, center[0]+r, center[1]+r],
                      fill=(255, 200, 50, alpha))
-gradient.save('TheatreGame/Content/light_gradient.png')
+save_if_missing(gradient, 'TheatreGame/Content/light_gradient.png')


### PR DESCRIPTION
## Summary
- skip texture generation when files already exist
- load light gradient texture and color effect
- adjust campfire sprite position
- highlight tiles around the campfire with a 3 tile range

## Testing
- `dotnet build TheatreGame/TheatreGame.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b953b00c8326b5eb370ea7bae49f