### PR TITLE
Dim campfire light and add AI texture generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ Prototype de jeu 3D isométrique utilisant MonoGame.
    ```bash
    python3 generate_textures.py
    ```
-5. Lancer le jeu :
+5. (Optionnel) Générer des textures de meilleure qualité avec un modèle Stable Diffusion :
+   ```bash
+   pip install --user torch diffusers transformers
+   python3 generate_ai_textures.py
+   ```
+6. Lancer le jeu :
    ```bash
    dotnet run --project TheatreGame
    ```
@@ -26,4 +31,4 @@ Prototype de jeu 3D isométrique utilisant MonoGame.
 
 - Fenêtre : 1280x720
 - Caméra : perspective isométrique simple
-- Les textures de la scène sont générées avec `generate_textures.py`.
+- Les textures de la scène sont générées avec `generate_textures.py` ou, pour un rendu plus réaliste, avec `generate_ai_textures.py`.

--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -369,7 +369,7 @@ namespace TheatreGame
 
         private void DrawCampfire()
         {
-            float flicker = 0.1f + (float)_random.NextDouble() * 0.05f;
+            float flicker = (0.1f + (float)_random.NextDouble() * 0.05f) * 0.2f;
             _spriteBatch.Begin(blendState: BlendState.AlphaBlend);
             _spriteBatch.Draw(_campfireTexture, _campfireScreenPos - new Vector2(32, 64),
                 null, Color.White, 0f, Vector2.Zero, 0.5f, SpriteEffects.None, 0f);

--- a/generate_ai_textures.py
+++ b/generate_ai_textures.py
@@ -1,0 +1,41 @@
+import os
+from PIL import Image
+
+try:
+    import torch
+    from diffusers import StableDiffusionPipeline
+except ImportError:
+    raise SystemExit("Please install torch and diffusers: pip install --user torch diffusers transformers")
+
+
+def generate_with_prompt(pipe, prompt: str, path: str, size=(512, 512)):
+    """Generate an image at ``path`` using ``prompt`` if the file is missing."""
+    if os.path.exists(path):
+        return
+    image = pipe(prompt).images[0]
+    image = image.resize(size, Image.ANTIALIAS)
+    image.save(path)
+
+
+def main():
+    os.makedirs('TheatreGame/Content', exist_ok=True)
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    pipe = StableDiffusionPipeline.from_pretrained('runwayml/stable-diffusion-v1-5')
+    pipe = pipe.to(device)
+
+    generate_with_prompt(pipe,
+                        'top down view wooden floor texture for a small stage',
+                        'TheatreGame/Content/stage_floor_hd.png')
+    generate_with_prompt(pipe,
+                        'theatrical red curtain texture, folds and shadows',
+                        'TheatreGame/Content/curtain_hd.png')
+    generate_with_prompt(pipe,
+                        'glowing campfire with visible logs, isolated on transparent background',
+                        'TheatreGame/Content/campfire_hd.png')
+    generate_with_prompt(pipe,
+                        'simple wooden pawn game piece on transparent background',
+                        'TheatreGame/Content/pawn_hd.png')
+
+
+if __name__ == '__main__':
+    main()

--- a/generate_textures.py
+++ b/generate_textures.py
@@ -32,9 +32,9 @@ square = 16
 for y in range(0, height, square):
     for x in range(0, width, square):
         if ((x // square) + (y // square)) % 2 == 0:
-            color = (200, 200, 200, 25)
+            color = (0, 0, 0, 30)
         else:
-            color = (120, 120, 120, 25)
+            color = (0, 0, 0, 15)
         grid_draw.rectangle([x, y, x + square, y + square], fill=color)
 save_if_missing(grid, 'TheatreGame/Content/grid_overlay.png')
 


### PR DESCRIPTION
## Summary
- tone down campfire light by 80%
- introduce `generate_ai_textures.py` using Stable Diffusion to create high quality textures
- document the new script and usage

## Testing
- `pip install --user pillow`
- `python3 generate_textures.py`
- `dotnet build TheatreGame/TheatreGame.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c51b10e48326b1b3a23d74c1d5ef