### PR TITLE
Fix Pillow constant for resampling

### DIFF
--- a/generate_ai_textures.py
+++ b/generate_ai_textures.py
@@ -13,7 +13,9 @@ def generate_with_prompt(pipe, prompt: str, path: str, size=(512, 512)):
     if os.path.exists(path):
         return
     image = pipe(prompt).images[0]
-    image = image.resize(size, Image.ANTIALIAS)
+    # Pillow removed ``Image.ANTIALIAS`` in version 10; ``Image.LANCZOS`` is the
+    # recommended replacement and is compatible with older versions too.
+    image = image.resize(size, Image.LANCZOS)
     image.save(path)
 
 


### PR DESCRIPTION
## Summary
- update `generate_ai_textures.py` to use `Image.LANCZOS` instead of deprecated `Image.ANTIALIAS`

## Testing
- `python3 -m py_compile generate_ai_textures.py`
- `python3 -m py_compile generate_textures.py`
- ❌ `dotnet restore TheatreGame/TheatreGame.csproj` (failed: `dotnet` not found)

------
https://chatgpt.com/codex/tasks/task_e_6844cfa594188326810cd5b2d9cbdeb8