### PR TITLE
Add pixel art texture generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Prototype de jeu 3D isométrique utilisant MonoGame.
    ```bash
    python3 generate_textures.py
    ```
-5. (Optionnel) Générer des textures de meilleure qualité avec un modèle Stable Diffusion :
+5. (Optionnel) Générer des textures en pixel art avec Stable Diffusion :
    ```bash
    pip install --user torch diffusers transformers
    python3 generate_ai_textures.py
@@ -31,4 +31,4 @@ Prototype de jeu 3D isométrique utilisant MonoGame.
 
 - Fenêtre : 1280x720
 - Caméra : perspective isométrique simple
-- Les textures de la scène sont générées avec `generate_textures.py` ou, pour un rendu plus réaliste, avec `generate_ai_textures.py`.
+- Les textures de la scène sont générées avec `generate_textures.py` ou, pour un rendu pixel art via l'IA, avec `generate_ai_textures.py`.


### PR DESCRIPTION
## Summary
- update `generate_ai_textures.py` to produce 64x64 pixel art textures
- document usage of the pixel art generator in README

## Testing
- `python3 -m py_compile generate_ai_textures.py generate_textures.py`

------
https://chatgpt.com/codex/tasks/task_e_6844d10f49ac8326a2d3a38db57a074b