### PR TITLE
Add player movement path and loading spinner

### DIFF
--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -63,7 +63,7 @@ namespace TheatreGame
             public bool IsPlayer;
         }
 
-        private List<Character> _characters;
+        private List<Character> _characters = new List<Character>();
         private Point? _hoveredTile;
         private Point? _selectedTile;
         private List<Point> _playerPath;

--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -24,6 +24,8 @@ namespace TheatreGame
 
         private Texture2D _campfireTexture;
         private Texture2D _pawnTexture;
+        private Texture2D _bishopTexture;
+        private Texture2D _spinnerTexture;
         private Texture2D _lightGradientTexture;
 
         private Texture2D _particleTexture;
@@ -55,9 +57,19 @@ namespace TheatreGame
         {
             public Point BoardPos;
             public Vector2 ScreenPos;
+            public Queue<Point> Path = new Queue<Point>();
+            public float MoveProgress = 0f;
+            public Texture2D Texture;
+            public bool IsPlayer;
         }
 
         private List<Character> _characters;
+        private Point? _hoveredTile;
+        private Point? _selectedTile;
+        private List<Point> _playerPath;
+        private List<Point> _aiPath;
+        private bool _moving;
+        private float _spinnerRotation;
 
         private struct Particle
         {
@@ -127,15 +139,22 @@ namespace TheatreGame
                 _campfireScreenPos, 15f);
 
             _characters = new List<Character>();
-            var heroPos = new Point(5, 4);
 
-            var heroScreen = GraphicsDevice.Viewport.Project(
-                new Vector3((heroPos.X - 3.5f) * CellSize, 0f, (heroPos.Y - 3.5f) * CellSize),
-                _projectionMatrix, _viewMatrix, Matrix.Identity);
+
+            var playerPos = new Point(4, 7);
             _characters.Add(new Character
             {
-                BoardPos = heroPos,
-                ScreenPos = new Vector2(heroScreen.X, heroScreen.Y)
+                BoardPos = playerPos,
+                ScreenPos = BoardToScreen(playerPos),
+                IsPlayer = true
+            });
+
+            var aiPos = new Point(4, 0);
+            _characters.Add(new Character
+            {
+                BoardPos = aiPos,
+                ScreenPos = BoardToScreen(aiPos),
+                IsPlayer = false
             });
 
             int buttonWidth = 140;
@@ -181,12 +200,23 @@ namespace TheatreGame
             _pawnTexture = Texture2D.FromStream(
                 GraphicsDevice,
                 TitleContainer.OpenStream("Content/pawn.png"));
+            _bishopTexture = Texture2D.FromStream(
+                GraphicsDevice,
+                TitleContainer.OpenStream("Content/bishop.png"));
             _lightGradientTexture = Texture2D.FromStream(
                 GraphicsDevice,
                 TitleContainer.OpenStream("Content/light_gradient.png"));
             _endTurnButtonTexture = Texture2D.FromStream(
                 GraphicsDevice,
                 TitleContainer.OpenStream("Content/end_turn.png"));
+            _spinnerTexture = Texture2D.FromStream(
+                GraphicsDevice,
+                TitleContainer.OpenStream("Content/spinner.png"));
+
+            for (int i = 0; i < _characters.Count; i++)
+            {
+                _characters[i].Texture = _bishopTexture;
+            }
 
             _fontSystem = new FontStashSharp.FontSystem();
             using (var fs = TitleContainer.OpenStream("Content/DejaVuSans.ttf"))
@@ -216,25 +246,82 @@ namespace TheatreGame
             _time += (float)gameTime.ElapsedGameTime.TotalSeconds;
 
             var mouse = Mouse.GetState();
-            if (mouse.LeftButton == ButtonState.Pressed &&
-                _prevMouseState.LeftButton == ButtonState.Released &&
-                _endTurnButtonRect.Contains(mouse.Position))
+            if (!_moving)
             {
-                EndTurn();
+                if (mouse.LeftButton == ButtonState.Pressed &&
+                    _prevMouseState.LeftButton == ButtonState.Released &&
+                    _endTurnButtonRect.Contains(mouse.Position))
+                {
+                    EndTurn();
+                }
+
+                _hoveredTile = ScreenToBoard(mouse.Position);
+
+                if (mouse.LeftButton == ButtonState.Pressed &&
+                    _prevMouseState.LeftButton == ButtonState.Released &&
+                    !_endTurnButtonRect.Contains(mouse.Position) && _hoveredTile.HasValue)
+                {
+                    var player = _characters.Find(c => c.IsPlayer);
+                    bool[,] occ = GetOccupied();
+                    var path = FindPath(player.BoardPos, _hoveredTile.Value, occ);
+                    if (path != null && path.Count <= 8)
+                    {
+                        _selectedTile = _hoveredTile;
+                        _playerPath = path;
+                    }
+                }
             }
             _prevMouseState = mouse;
+
+            if (_moving)
+            {
+                bool anyMoving = false;
+                for (int i = 0; i < _characters.Count; i++)
+                {
+                    var c = _characters[i];
+                    if (c.Path.Count > 0)
+                    {
+                        anyMoving = true;
+                        Point next = c.Path.Peek();
+                        Vector2 from = BoardToScreen(c.BoardPos);
+                        Vector2 to = BoardToScreen(next);
+                        c.MoveProgress += 3f * (float)gameTime.ElapsedGameTime.TotalSeconds;
+                        float t = MathF.Min(1f, c.MoveProgress);
+                        c.ScreenPos = Vector2.Lerp(from, to, t);
+                        if (c.MoveProgress >= 1f)
+                        {
+                            c.BoardPos = next;
+                            c.Path.Dequeue();
+                            c.MoveProgress = 0f;
+                            c.ScreenPos = BoardToScreen(c.BoardPos);
+                        }
+                        _characters[i] = c;
+                    }
+                }
+
+                _spinnerRotation += 5f * (float)gameTime.ElapsedGameTime.TotalSeconds;
+                if (!anyMoving)
+                {
+                    _moving = false;
+                    _playerPath = null;
+                    _aiPath = null;
+                    _selectedTile = null;
+                    _turn++;
+                }
+            }
+            else
+            {
+                for (int i = 0; i < _characters.Count; i++)
+                {
+                    var c = _characters[i];
+                    c.ScreenPos = Vector2.Lerp(c.ScreenPos, BoardToScreen(c.BoardPos), 0.1f);
+                    _characters[i] = c;
+                }
+            }
             UpdateParticles(gameTime, _lightParticles);
             UpdateParticles(gameTime, _dustParticles);
             UpdateFireParticles(gameTime, _fireParticles, _campfireScreenPos, 10f);
             UpdateFireParticles(gameTime, _smokeParticles, _campfireScreenPos, 20f);
-
-            for (int i = 0; i < _characters.Count; i++)
-            {
-                var c = _characters[i];
-                var target = BoardToScreen(c.BoardPos);
-                c.ScreenPos = Vector2.Lerp(c.ScreenPos, target, 0.1f);
-                _characters[i] = c;
-            }
             UpdateGrainTexture();
 
             base.Update(gameTime);
@@ -279,6 +366,17 @@ namespace TheatreGame
             }
 
             DrawTileLights();
+            DrawHighlights();
+            if (_playerPath != null)
+            {
+                var player = _characters.Find(c => c.IsPlayer);
+                DrawPath(player.BoardPos, _playerPath, Color.LimeGreen);
+            }
+            if (_moving && _aiPath != null)
+            {
+                var ai = _characters.Find(c => !c.IsPlayer);
+                DrawPath(ai.BoardPos, _aiPath, Color.Orange);
+            }
             DrawCampfire();
             DrawCharacters();
             DrawParticles();
@@ -399,12 +497,113 @@ namespace TheatreGame
             return new Vector2(screen.X, screen.Y);
         }
 
+        private Point? ScreenToBoard(Point screen)
+        {
+            Vector3 nearSource = new Vector3(screen.X, screen.Y, 0f);
+            Vector3 farSource = new Vector3(screen.X, screen.Y, 1f);
+            Vector3 nearPoint = GraphicsDevice.Viewport.Unproject(nearSource,
+                _projectionMatrix, _viewMatrix, Matrix.Identity);
+            Vector3 farPoint = GraphicsDevice.Viewport.Unproject(farSource,
+                _projectionMatrix, _viewMatrix, Matrix.Identity);
+            Vector3 direction = Vector3.Normalize(farPoint - nearPoint);
+            if (direction.Y >= 0f)
+                return null;
+            float distance = -nearPoint.Y / direction.Y;
+            Vector3 world = nearPoint + direction * distance;
+            int x = (int)Math.Floor(world.X / CellSize + 3.5f);
+            int y = (int)Math.Floor(world.Z / CellSize + 3.5f);
+            if (x < 0 || x > 7 || y < 0 || y > 7)
+                return null;
+            return new Point(x, y);
+        }
+
+        private void DrawLine(Vector2 start, Vector2 end, Color color, float thickness)
+        {
+            Vector2 edge = end - start;
+            float angle = (float)Math.Atan2(edge.Y, edge.X);
+            _spriteBatch.Draw(_particleTexture, start, null, color, angle, Vector2.Zero,
+                new Vector2(edge.Length(), thickness), SpriteEffects.None, 0f);
+        }
+
+        private void DrawPath(Point start, List<Point> path, Color color)
+        {
+            if (path == null || path.Count == 0)
+                return;
+
+            _spriteBatch.Begin();
+            Vector2 from = BoardToScreen(start);
+            foreach (var step in path)
+            {
+                Vector2 to = BoardToScreen(step);
+                DrawLine(from, to, color, 3f);
+                from = to;
+            }
+            _spriteBatch.End();
+        }
+
+        private List<Point> FindPath(Point start, Point goal, bool[,] occupied)
+        {
+            if (occupied[goal.X, goal.Y])
+                return null;
+
+            Queue<Point> q = new Queue<Point>();
+            q.Enqueue(start);
+            Dictionary<Point, Point> prev = new Dictionary<Point, Point>();
+            prev[start] = start;
+            Point[] dirs = new[] { new Point(1,0), new Point(-1,0), new Point(0,1), new Point(0,-1) };
+
+            while (q.Count > 0)
+            {
+                Point cur = q.Dequeue();
+                if (cur == goal)
+                    break;
+                foreach (var d in dirs)
+                {
+                    int nx = cur.X + d.X;
+                    int ny = cur.Y + d.Y;
+                    if (nx < 0 || nx > 7 || ny < 0 || ny > 7)
+                        continue;
+                    Point np = new Point(nx, ny);
+                    if (occupied[nx, ny] && np != goal)
+                        continue;
+                    if (!prev.ContainsKey(np))
+                    {
+                        prev[np] = cur;
+                        q.Enqueue(np);
+                    }
+                }
+            }
+
+            if (!prev.ContainsKey(goal))
+                return null;
+
+            List<Point> path = new List<Point>();
+            Point p = goal;
+            while (p != start)
+            {
+                path.Insert(0, p);
+                p = prev[p];
+            }
+            return path;
+        }
+
+        private bool[,] GetOccupied()
+        {
+            bool[,] occ = new bool[8, 8];
+            foreach (var c in _characters)
+            {
+                occ[c.BoardPos.X, c.BoardPos.Y] = true;
+            }
+            return occ;
+        }
+
         private void DrawCharacters()
         {
             _spriteBatch.Begin(blendState: BlendState.AlphaBlend);
             foreach (var c in _characters)
             {
-                _spriteBatch.Draw(_pawnTexture, c.ScreenPos - new Vector2(32, 64),
+                var tex = c.Texture ?? _pawnTexture;
+                _spriteBatch.Draw(tex, c.ScreenPos - new Vector2(32, 64),
                     null, Color.White, 0f, Vector2.Zero, 0.5f, SpriteEffects.None, 0f);
             }
             _spriteBatch.End();
@@ -446,6 +645,24 @@ namespace TheatreGame
             {
                 pass.Apply();
                 GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, verts, 0, 2);
+            }
+        }
+
+        private void DrawHighlights()
+        {
+            if (_hoveredTile.HasValue && !_moving)
+            {
+                var player = _characters.Find(c => c.IsPlayer);
+                bool[,] occ = GetOccupied();
+                var path = FindPath(player.BoardPos, _hoveredTile.Value, occ);
+                bool ok = path != null && path.Count <= 8 && !occ[_hoveredTile.Value.X, _hoveredTile.Value.Y];
+                Color color = ok ? new Color(0, 255, 0, 100) : new Color(255, 0, 0, 100);
+                DrawTileQuad((_hoveredTile.Value.X - 3.5f) * CellSize, (_hoveredTile.Value.Y - 3.5f) * CellSize, CellSize, color);
+            }
+            if (_selectedTile.HasValue)
+            {
+                Color color = new Color(0, 200, 0, 120);
+                DrawTileQuad((_selectedTile.Value.X - 3.5f) * CellSize, (_selectedTile.Value.Y - 3.5f) * CellSize, CellSize, color);
             }
         }
 
@@ -506,20 +723,43 @@ namespace TheatreGame
 
         private void EndTurn()
         {
-            if (_characters.Count == 0)
+            if (_moving)
                 return;
 
-            var hero = _characters[0];
-            Point[] dirs = new[]
+            var player = _characters.Find(c => c.IsPlayer);
+            var ai = _characters.Find(c => !c.IsPlayer);
+
+            bool[,] occ = GetOccupied();
+
+            if (_playerPath != null)
             {
-                new Point(1,0), new Point(-1,0), new Point(0,1), new Point(0,-1)
-            };
-            Point dir = dirs[_random.Next(dirs.Length)];
-            hero.BoardPos = new Point(
-                Math.Clamp(hero.BoardPos.X + dir.X, 0, 7),
-                Math.Clamp(hero.BoardPos.Y + dir.Y, 0, 7));
-            _characters[0] = hero;
-            _turn++;
+                foreach (var step in _playerPath)
+                    player.Path.Enqueue(step);
+            }
+
+            Point aiDest;
+            List<Point> aiPath = null;
+            do
+            {
+                aiDest = new Point(_random.Next(8), _random.Next(8));
+                aiPath = FindPath(ai.BoardPos, aiDest, occ);
+            } while (aiPath == null || aiPath.Count > 8);
+
+            foreach (var step in aiPath)
+                ai.Path.Enqueue(step);
+
+            _aiPath = aiPath;
+
+            for (int i = 0; i < _characters.Count; i++)
+            {
+                if (_characters[i].IsPlayer)
+                    _characters[i] = player;
+                else
+                    _characters[i] = ai;
+            }
+
+            _moving = true;
+            _spinnerRotation = 0f;
         }
 
         private void DrawUI()
@@ -548,6 +788,15 @@ namespace TheatreGame
             startY += lineHeight + vertSpace;
             _spriteBatch.DrawString(_font, $"Map: {MapName}", new Vector2(marginX, startY), Color.White);
             _spriteBatch.End();
+
+            if (_moving)
+            {
+                Vector2 center = new Vector2(_graphics.PreferredBackBufferWidth / 2f, _graphics.PreferredBackBufferHeight / 2f);
+                _spriteBatch.Begin();
+                _spriteBatch.Draw(_spinnerTexture, center, null, Color.White, _spinnerRotation,
+                    new Vector2(_spinnerTexture.Width / 2f, _spinnerTexture.Height / 2f), 1f, SpriteEffects.None, 0f);
+                _spriteBatch.End();
+            }
         }
     }
 }

--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -648,6 +648,21 @@ namespace TheatreGame
             }
         }
 
+        private void DrawTileBorder(Point tile, Color color)
+        {
+            Vector2 tl = BoardToScreen(tile);
+            Vector2 tr = BoardToScreen(new Point(tile.X + 1, tile.Y));
+            Vector2 br = BoardToScreen(new Point(tile.X + 1, tile.Y + 1));
+            Vector2 bl = BoardToScreen(new Point(tile.X, tile.Y + 1));
+
+            _spriteBatch.Begin();
+            DrawLine(tl, tr, color, 2f);
+            DrawLine(tr, br, color, 2f);
+            DrawLine(br, bl, color, 2f);
+            DrawLine(bl, tl, color, 2f);
+            _spriteBatch.End();
+        }
+
         private void DrawHighlights()
         {
             if (_hoveredTile.HasValue && !_moving)
@@ -656,13 +671,21 @@ namespace TheatreGame
                 bool[,] occ = GetOccupied();
                 var path = FindPath(player.BoardPos, _hoveredTile.Value, occ);
                 bool ok = path != null && path.Count <= 8 && !occ[_hoveredTile.Value.X, _hoveredTile.Value.Y];
-                Color color = ok ? new Color(0, 255, 0, 100) : new Color(255, 0, 0, 100);
-                DrawTileQuad((_hoveredTile.Value.X - 3.5f) * CellSize, (_hoveredTile.Value.Y - 3.5f) * CellSize, CellSize, color);
+                Color fill = ok ? new Color(0, 255, 0, 40) : new Color(255, 0, 0, 40);
+                Color border = ok ? Color.LimeGreen : Color.Red;
+
+                GraphicsDevice.BlendState = BlendState.AlphaBlend;
+                DrawTileQuad((_hoveredTile.Value.X - 3.5f) * CellSize, (_hoveredTile.Value.Y - 3.5f) * CellSize, CellSize, fill);
+                DrawTileBorder(_hoveredTile.Value, border);
+                GraphicsDevice.BlendState = BlendState.Opaque;
             }
+
             if (_selectedTile.HasValue)
             {
-                Color color = new Color(0, 200, 0, 120);
-                DrawTileQuad((_selectedTile.Value.X - 3.5f) * CellSize, (_selectedTile.Value.Y - 3.5f) * CellSize, CellSize, color);
+                GraphicsDevice.BlendState = BlendState.AlphaBlend;
+                DrawTileQuad((_selectedTile.Value.X - 3.5f) * CellSize, (_selectedTile.Value.Y - 3.5f) * CellSize, CellSize, new Color(0, 200, 0, 60));
+                DrawTileBorder(_selectedTile.Value, Color.Green);
+                GraphicsDevice.BlendState = BlendState.Opaque;
             }
         }
 
@@ -760,6 +783,7 @@ namespace TheatreGame
 
             _moving = true;
             _spinnerRotation = 0f;
+            _hoveredTile = null;
         }
 
         private void DrawUI()
@@ -769,14 +793,17 @@ namespace TheatreGame
                 _graphics.PreferredBackBufferWidth, ToolbarHeight);
             _spriteBatch.Begin();
             _spriteBatch.Draw(_particleTexture, bar, Color.Black * 0.5f);
-            _spriteBatch.Draw(_endTurnButtonTexture, _endTurnButtonRect, Color.White);
+            if (!_moving)
+            {
+                _spriteBatch.Draw(_endTurnButtonTexture, _endTurnButtonRect, Color.White);
 
-            string buttonText = "End Turn";
-            Vector2 btnSize = _font.MeasureString(buttonText);
-            Vector2 btnPos = new Vector2(
-                _endTurnButtonRect.Center.X - btnSize.X / 2f,
-                _endTurnButtonRect.Center.Y - btnSize.Y / 2f);
-            _spriteBatch.DrawString(_font, buttonText, btnPos, Color.White);
+                string buttonText = "End Turn";
+                Vector2 btnSize = _font.MeasureString(buttonText);
+                Vector2 btnPos = new Vector2(
+                    _endTurnButtonRect.Center.X - btnSize.X / 2f,
+                    _endTurnButtonRect.Center.Y - btnSize.Y / 2f);
+                _spriteBatch.DrawString(_font, buttonText, btnPos, Color.White);
+            }
 
             float marginX = 20f;
             float lineHeight = _font.LineHeight;

--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -490,6 +490,11 @@ namespace TheatreGame
 
         private Vector2 BoardToScreen(Point boardPos)
         {
+            return BoardToScreen(new Vector2(boardPos.X, boardPos.Y));
+        }
+
+        private Vector2 BoardToScreen(Vector2 boardPos)
+        {
             Vector3 world = new Vector3((boardPos.X - 3.5f) * CellSize, 0f,
                 (boardPos.Y - 3.5f) * CellSize);
             var screen = GraphicsDevice.Viewport.Project(world,
@@ -650,10 +655,10 @@ namespace TheatreGame
 
         private void DrawTileBorder(Point tile, Color color)
         {
-            Vector2 tl = BoardToScreen(tile);
-            Vector2 tr = BoardToScreen(new Point(tile.X + 1, tile.Y));
-            Vector2 br = BoardToScreen(new Point(tile.X + 1, tile.Y + 1));
-            Vector2 bl = BoardToScreen(new Point(tile.X, tile.Y + 1));
+            Vector2 tl = BoardToScreen(new Vector2(tile.X - 0.5f, tile.Y - 0.5f));
+            Vector2 tr = BoardToScreen(new Vector2(tile.X + 0.5f, tile.Y - 0.5f));
+            Vector2 br = BoardToScreen(new Vector2(tile.X + 0.5f, tile.Y + 0.5f));
+            Vector2 bl = BoardToScreen(new Vector2(tile.X - 0.5f, tile.Y + 0.5f));
 
             _spriteBatch.Begin();
             DrawLine(tl, tr, color, 2f);
@@ -675,7 +680,7 @@ namespace TheatreGame
                 Color border = ok ? Color.LimeGreen : Color.Red;
 
                 GraphicsDevice.BlendState = BlendState.AlphaBlend;
-                DrawTileQuad((_hoveredTile.Value.X - 3.5f) * CellSize, (_hoveredTile.Value.Y - 3.5f) * CellSize, CellSize, fill);
+                DrawTileQuad((_hoveredTile.Value.X - 4) * CellSize, (_hoveredTile.Value.Y - 4) * CellSize, CellSize, fill);
                 DrawTileBorder(_hoveredTile.Value, border);
                 GraphicsDevice.BlendState = BlendState.Opaque;
             }
@@ -683,7 +688,7 @@ namespace TheatreGame
             if (_selectedTile.HasValue)
             {
                 GraphicsDevice.BlendState = BlendState.AlphaBlend;
-                DrawTileQuad((_selectedTile.Value.X - 3.5f) * CellSize, (_selectedTile.Value.Y - 3.5f) * CellSize, CellSize, new Color(0, 200, 0, 60));
+                DrawTileQuad((_selectedTile.Value.X - 4) * CellSize, (_selectedTile.Value.Y - 4) * CellSize, CellSize, new Color(0, 200, 0, 60));
                 DrawTileBorder(_selectedTile.Value, Color.Green);
                 GraphicsDevice.BlendState = BlendState.Opaque;
             }

--- a/generate_textures.py
+++ b/generate_textures.py
@@ -95,3 +95,27 @@ try:
 except Exception:
     pass
 save_if_missing(button, 'TheatreGame/Content/end_turn.png')
+
+# Simple bishop-like piece texture
+bishop = Image.new('RGBA', (128, 128), (0, 0, 0, 0))
+bishop_draw = ImageDraw.Draw(bishop)
+bishop_draw.ellipse([32, 96, 96, 120], fill=(0, 0, 0))
+bishop_draw.polygon([(64, 24), (48, 80), (80, 80)], fill=(0, 0, 0))
+bishop_draw.ellipse([56, 20, 72, 36], fill=(0, 0, 0))
+save_if_missing(bishop, 'TheatreGame/Content/bishop.png')
+
+# Loading spinner texture (ring with a missing quarter)
+spinner_size = 64
+spinner = Image.new('RGBA', (spinner_size, spinner_size), (0, 0, 0, 0))
+spinner_draw = ImageDraw.Draw(spinner)
+outer_r = spinner_size // 2
+inner_r = spinner_size // 2 - 6
+spinner_draw.ellipse([
+    spinner_size/2 - outer_r, spinner_size/2 - outer_r,
+    spinner_size/2 + outer_r, spinner_size/2 + outer_r
+], outline=(200, 200, 200, 255), width=6)
+spinner_draw.pieslice([
+    spinner_size/2 - outer_r, spinner_size/2 - outer_r,
+    spinner_size/2 + outer_r, spinner_size/2 + outer_r
+], 0, 90, fill=(0, 0, 0, 0))
+save_if_missing(spinner, 'TheatreGame/Content/spinner.png')


### PR DESCRIPTION
## Summary
- add bishop piece and spinner textures generation
- enhance character data with path info and state flags
- implement tile selection, pathfinding and AI random movement
- highlight board tiles on hover and selection
- show movement paths and rotating spinner during processing

## Testing
- `python3 generate_textures.py`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459e2d0e208326adea23e4d2f48649