### PR TITLE
Fix sprite scaling and shadow lag

### DIFF
--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -85,6 +85,8 @@ namespace TheatreGame
         private bool _moving;
         private float _spinnerRotation;
 
+        private float _initialCameraDistance;
+
         private struct Particle
         {
             public Vector2 Position;
@@ -112,6 +114,7 @@ namespace TheatreGame
             _cameraTarget = Vector3.Zero;
             _cameraPosition = new Vector3(20, 20, 20);
             _cameraDistance = (_cameraPosition - _cameraTarget).Length();
+            _initialCameraDistance = _cameraDistance;
             var up = Vector3.Up;
             _viewMatrix = Matrix.CreateLookAt(_cameraPosition, _cameraTarget, up);
             _projectionMatrix = Matrix.CreatePerspectiveFieldOfView(MathHelper.ToRadians(45f),
@@ -386,7 +389,7 @@ namespace TheatreGame
                 for (int i = 0; i < _characters.Count; i++)
                 {
                     var c = _characters[i];
-                    c.ScreenPos = Vector2.Lerp(c.ScreenPos, BoardToScreen(c.BoardPos), 0.1f);
+                    c.ScreenPos = BoardToScreen(c.BoardPos);
                     _characters[i] = c;
                 }
             }
@@ -686,12 +689,15 @@ namespace TheatreGame
 
         private void DrawCharacters()
         {
+            float spriteScale = 0.5f * _initialCameraDistance / _cameraDistance;
             _spriteBatch.Begin(blendState: BlendState.AlphaBlend);
             foreach (var c in _characters)
             {
                 var tex = c.Texture ?? _pawnTexture;
-                _spriteBatch.Draw(tex, c.ScreenPos - new Vector2(32, 64),
-                    null, Color.White, 0f, Vector2.Zero, 0.5f, SpriteEffects.None, 0f);
+                Vector2 offset = new Vector2(tex.Width * spriteScale / 2f,
+                                             tex.Height * spriteScale);
+                _spriteBatch.Draw(tex, c.ScreenPos - offset,
+                    null, Color.White, 0f, Vector2.Zero, spriteScale, SpriteEffects.None, 0f);
             }
             _spriteBatch.End();
         }
@@ -715,10 +721,10 @@ namespace TheatreGame
                     dir /= dist;
 
                     float rotation = (float)Math.Atan2(dir.Y, dir.X) + MathHelper.PiOver2;
-                    float baseScale = 0.5f;
+                    float baseScale = 0.5f * _initialCameraDistance / _cameraDistance;
                     float length = MathHelper.Clamp(dist / 100f, 0.5f, 2f);
                     Vector2 scale = new Vector2(baseScale * 0.3f, baseScale) * length;
-                    Vector2 pos = c.ScreenPos + dir * 2f;
+                    Vector2 pos = c.ScreenPos;
 
                     _spriteBatch.Draw(tex, pos, null, new Color(0, 0, 0, 150), rotation,
                         new Vector2(tex.Width / 2f, tex.Height), scale, SpriteEffects.None, 0f);


### PR DESCRIPTION
## Summary
- keep character shadows attached to the feet
- scale characters based on zoom level
- keep characters aligned with camera without smoothing

## Testing
- `dotnet build TheatreGame/TheatreGame.csproj -nologo` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845d2c6e1288326905833c9abfd43f7