### PR TITLE
Implement fog of war

### DIFF
--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -82,7 +82,7 @@ namespace TheatreGame
 
         private List<Character> _characters = new List<Character>();
         private bool[,] _fog = new bool[8,8];
-        private readonly Point _campfireTile = new Point(4, 4);
+        private readonly Point _campfireTile = new Point(4, 3);
         private Point? _hoveredTile;
         private Point? _selectedTile;
         private List<Point> _playerPath;
@@ -152,7 +152,10 @@ namespace TheatreGame
             _dustParticles = new List<Particle>();
             _fireParticles = new List<Particle>();
             _smokeParticles = new List<Particle>();
-            _lightPositions = new List<Vector3> { Vector3.Zero }; // campfire
+            _lightPositions = new List<Vector3>
+            {
+                BoardToWorld(new Vector2(_campfireTile.X, _campfireTile.Y))
+            };
             SpawnParticles(_lightParticles, 100, new Color(255, 255, 200, 200));
             SpawnParticles(_dustParticles, 200, new Color(150, 120, 100, 150));
 
@@ -337,7 +340,7 @@ namespace TheatreGame
             _cameraTarget.Z = MathHelper.Clamp(_cameraTarget.Z, -CameraMoveLimit, CameraMoveLimit);
             _cameraPosition = _cameraTarget + direction * _cameraDistance;
             _viewMatrix = Matrix.CreateLookAt(_cameraPosition, _cameraTarget, Vector3.Up);
-            var campfireScreen = GraphicsDevice.Viewport.Project(Vector3.Zero, _projectionMatrix, _viewMatrix, Matrix.Identity);
+            var campfireScreen = GraphicsDevice.Viewport.Project(_lightPositions[0], _projectionMatrix, _viewMatrix, Matrix.Identity);
             _campfireScreenPos = new Vector2(campfireScreen.X, campfireScreen.Y);
             Vector2 campfireDelta = _campfireScreenPos - _prevCampfireScreenPos;
             if (!_moving)

--- a/TheatreGame/Game1.cs
+++ b/TheatreGame/Game1.cs
@@ -82,6 +82,7 @@ namespace TheatreGame
 
         private List<Character> _characters = new List<Character>();
         private bool[,] _fog = new bool[8,8];
+        private readonly Point _campfireTile = new Point(4, 4);
         private Point? _hoveredTile;
         private Point? _selectedTile;
         private List<Point> _playerPath;
@@ -569,22 +570,25 @@ namespace TheatreGame
             }
             _spriteBatch.End();
 
-            _spriteBatch.Begin(blendState: BlendState.Additive);
-            foreach (var p in _fireParticles)
+            if (IsTileVisible(_campfireTile))
             {
-                _spriteBatch.Draw(_particleTexture, p.Position, null, p.Color,
-                    0f, Vector2.Zero, p.Scale, SpriteEffects.None, 0f);
-            }
-            _spriteBatch.End();
+                _spriteBatch.Begin(blendState: BlendState.Additive);
+                foreach (var p in _fireParticles)
+                {
+                    _spriteBatch.Draw(_particleTexture, p.Position, null, p.Color,
+                        0f, Vector2.Zero, p.Scale, SpriteEffects.None, 0f);
+                }
+                _spriteBatch.End();
 
-            _spriteBatch.Begin();
-            float smokeRatio = GetScaleForWorldPosition(Vector3.Zero, 1f);
-            foreach (var p in _smokeParticles)
-            {
-                _spriteBatch.Draw(_smokeTexture, p.Position, null, p.Color,
-                    0f, Vector2.Zero, p.Scale * smokeRatio, SpriteEffects.None, 0f);
+                _spriteBatch.Begin();
+                float smokeRatio = GetScaleForWorldPosition(Vector3.Zero, 1f);
+                foreach (var p in _smokeParticles)
+                {
+                    _spriteBatch.Draw(_smokeTexture, p.Position, null, p.Color,
+                        0f, Vector2.Zero, p.Scale * smokeRatio, SpriteEffects.None, 0f);
+                }
+                _spriteBatch.End();
             }
-            _spriteBatch.End();
         }
 
         private void DrawFog()
@@ -635,6 +639,8 @@ namespace TheatreGame
 
         private void DrawCampfire()
         {
+            if (!IsTileVisible(_campfireTile))
+                return;
             float flicker = (0.1f + (float)_random.NextDouble() * 0.05f) * 0.2f;
             _spriteBatch.Begin(blendState: BlendState.AlphaBlend);
             const float baseScale = 0.5f;
@@ -781,6 +787,8 @@ namespace TheatreGame
             _spriteBatch.Begin(blendState: BlendState.AlphaBlend);
             foreach (var c in _characters)
             {
+                if (!IsTileVisible(c.BoardPos))
+                    continue;
                 var tex = c.Texture ?? _pawnTexture;
                 Vector3 world = BoardToWorld(new Vector2(c.BoardPos.X, c.BoardPos.Y));
                 const float baseScale = 0.5f;
@@ -803,6 +811,8 @@ namespace TheatreGame
 
                 foreach (var c in _characters)
                 {
+                    if (!IsTileVisible(c.BoardPos))
+                        continue;
                     var tex = c.Texture ?? _pawnTexture;
                     Vector2 dir = c.ScreenPos - lightPos;
                     float dist = dir.Length();
@@ -1027,6 +1037,13 @@ namespace TheatreGame
                         _fog[x, y] = false;
                 }
             }
+        }
+
+        private bool IsTileVisible(Point tile)
+        {
+            if (tile.X < 0 || tile.X > 7 || tile.Y < 0 || tile.Y > 7)
+                return true;
+            return !_fog[tile.X, tile.Y];
         }
 
         private void EndTurn()

--- a/generate_textures.py
+++ b/generate_textures.py
@@ -126,3 +126,7 @@ smoke = Image.new('RGBA', (smoke_size, smoke_size), (0, 0, 0, 0))
 smoke_draw = ImageDraw.Draw(smoke)
 smoke_draw.ellipse([0, 0, smoke_size - 1, smoke_size - 1], fill=(128, 128, 128, 100))
 save_if_missing(smoke, 'TheatreGame/Content/smoke_particle.png')
+
+# Simple fog texture used for fog of war overlay
+fog = Image.new('RGBA', (128, 128), (100, 100, 100, 200))
+save_if_missing(fog, 'TheatreGame/Content/fog.png')


### PR DESCRIPTION
## Summary
- add fog of war texture generation
- implement fog state in `Game1`
- reveal tiles around the player
- hide everything during movement phase and restore visibility afterwards

## Testing
- `python3 generate_textures.py`
- `dotnet build TheatreGame/TheatreGame.csproj -nologo` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e9509cec8326b0fa3a2364c390dc